### PR TITLE
Added delay for airdrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# How to Run
+
+Need to have typescript installed for this.
+
+1) yarn
+2) ts-node index.ts

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,10 @@ const METAPLEX_PROGRAM_ID = new PublicKey(
   "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
 );
 
+function delay(ms: number) {
+  return new Promise( resolve => setTimeout(resolve, ms) );
+}
+
 async function main() {
   let connection: Connection = new Connection(
     "https://api.devnet.solana.com",
@@ -39,6 +43,8 @@ async function main() {
   let creator = new Keypair();
 
   await connection.requestAirdrop(creator.publicKey, 1 * LAMPORTS_PER_SOL);
+  
+  await delay(1000);
 
   let user = new PublicKey("AVdBTNhDqYgXGaaVkqiaUJ1Yqa61hMiFFaVRtqwzs5GZ");
 


### PR DESCRIPTION
seems the requestDrop() function did execute but the nft minting transaction was too fast, so I guess there was a bug which said the Minter has no balance, this is used to happens sometimes only tho, but it sure did happen and was frustrating. So added a short delay and now it always works. Also added a short README.md